### PR TITLE
Ignore TemplateLiterals

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Inline values from a JSON file eg. a config file
 
+> Does not work if the argument to `require()` is an identifier or a template literal
+
 ## Example
 
 **config.json**:

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ export default function ({types: t}) {
         if (t.isCallExpression(node.object) &&
             t.isIdentifier(node.object.callee, { name: 'require' }) &&
             t.isLiteral(node.object.arguments[0]) &&
+            !t.isTemplateLiteral(node.object.arguments[0]) &&
             node.object.arguments[0].value.match(re)) {
           let srcPath = nodePath.resolve(state.file.opts.filename);
           let requireText = node.object.arguments[0].value;


### PR DESCRIPTION
currently this plugin crashes for TemplateLiterals as they don't have `.value`

http://astexplorer.net/#/K4ZWK5GyYC